### PR TITLE
Add --new-session to prevent CVE-2017-5226 -- bubblewrap escape via TIOCSTI ioctl

### DIFF
--- a/wrap.sh
+++ b/wrap.sh
@@ -374,6 +374,7 @@ for e in "${env_vars[@]}"; do
 done
 
 exec bwrap \
+  --new-session \ # to prevent CVE-2017-5226 -- bubblewrap escape via TIOCSTI ioctl https://github.com/containers/bubblewrap/issues/142
   --chdir "$bwrap_chdir" \
   --clearenv \
   --dev /dev \


### PR DESCRIPTION
fish ( https://github.com/fish-shell/fish-shell/issues/9605 ) and some other programs might not work because of this sometimes breaking change

Nowadays its possible to disable TIOCSTI in the Linux kernel and thus preventing the vulnerability without the extra flag, but many dont do this. If it becomes default in newer kernels and the old ones phase out, this could be reverted.